### PR TITLE
Add MrAntiFun trainer provider

### DIFF
--- a/cheater/__init__.py
+++ b/cheater/__init__.py
@@ -1,0 +1,5 @@
+"""Cheater package."""
+
+from .search import search_all
+
+__all__ = ["search_all"]

--- a/cheater/providers/__init__.py
+++ b/cheater/providers/__init__.py
@@ -1,0 +1,7 @@
+"""Trainer providers."""
+
+from __future__ import annotations
+
+from .mrantifun import MrAntiFunProvider
+
+__all__ = ["MrAntiFunProvider"]

--- a/cheater/providers/mrantifun.py
+++ b/cheater/providers/mrantifun.py
@@ -1,0 +1,43 @@
+"""MrAntiFun trainer provider."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+from urllib.parse import quote_plus, urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+BASE_URL = "https://mrantifun.net"
+SEARCH_URL = BASE_URL + "/index.php?search/1&q={query}&o=date"
+
+
+@dataclass
+class Trainer:
+    """Representation of a trainer result."""
+
+    title: str
+    url: str
+    provider: str = "MrAntiFun"
+
+
+class MrAntiFunProvider:
+    """Provider for scraping trainers from mrantifun.net."""
+
+    def search(self, query: str) -> List[Trainer]:
+        """Search the MrAntiFun forums for trainers matching ``query``."""
+        encoded = quote_plus(query)
+        resp = requests.get(SEARCH_URL.format(query=encoded), timeout=15)
+        resp.raise_for_status()
+        return list(self.parse_search_results(resp.text))
+
+    @staticmethod
+    def parse_search_results(html: str) -> Iterable[Trainer]:
+        """Parse search results HTML and yield :class:`Trainer` objects."""
+        soup = BeautifulSoup(html, "html.parser")
+        for link in soup.select("h3.contentRow-title a"):
+            title = re.sub(r"\s+", " ", link.get_text(strip=True))
+            url = urljoin(BASE_URL, link.get("href"))
+            yield Trainer(title=title, url=url)

--- a/cheater/search.py
+++ b/cheater/search.py
@@ -1,0 +1,26 @@
+"""Unified trainer search across providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .providers import MrAntiFunProvider
+
+
+@dataclass
+class SearchResult:
+    title: str
+    url: str
+    provider: str
+
+
+def search_all(query: str) -> List[SearchResult]:
+    """Search all providers for ``query`` and return aggregated results."""
+    results: List[SearchResult] = []
+
+    provider = MrAntiFunProvider()
+    for trainer in provider.search(query):
+        results.append(SearchResult(trainer.title, trainer.url, trainer.provider))
+
+    return results

--- a/tests/providers/sample_search.html
+++ b/tests/providers/sample_search.html
@@ -1,0 +1,1630 @@
+<!DOCTYPE html>
+<html id="XF" lang="en-US" dir="LTR"
+	data-app="public"
+	data-template="search_results"
+	data-container-key=""
+	data-content-key=""
+	data-logged-in="false"
+	data-cookie-prefix="maf_"
+	data-csrf="1753044081,66474e5df4315843f5da3454ac773078"
+	class="has-no-js template-search_results"
+	>
+<head>
+	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+
+	
+	
+	
+
+	<title>Search results for query: Hitman | MrAntiFun, PC Video Game Trainers, Cheats and mods</title>
+
+	<link rel="manifest" href="/webmanifest.php">
+	
+		<meta name="theme-color" content="#171717" />
+	
+
+	<meta name="apple-mobile-web-app-title" content="MrAntiFun">
+	
+
+	
+		<meta name="robots" content="noindex" />
+	
+		<link rel="next" href="/search/16500161/?page=2&amp;q=Hitman&amp;o=date" />
+	
+
+	
+		
+	
+	
+	<meta property="og:site_name" content="MrAntiFun, PC Video Game Trainers, Cheats and mods" />
+
+
+	
+	
+		
+	
+	
+	<meta property="og:type" content="website" />
+
+
+	
+	
+		
+	
+	
+	
+		<meta property="og:title" content="Search results for query: Hitman" />
+		<meta property="twitter:title" content="Search results for query: Hitman" />
+	
+
+
+	
+	
+	
+		
+	
+	
+	<meta property="og:url" content="https://mrantifun.net/search/16500161/?q=Hitman&amp;o=date" />
+
+
+	
+	
+
+	
+	
+
+	
+
+
+	<link rel="preload" href="/styles/fonts/fa/fa-regular-400.woff2?_v=5.15.1" as="font" type="font/woff2" crossorigin="anonymous" />
+
+
+	<link rel="preload" href="/styles/fonts/fa/fa-solid-900.woff2?_v=5.15.1" as="font" type="font/woff2" crossorigin="anonymous" />
+
+
+<link rel="preload" href="/styles/fonts/fa/fa-brands-400.woff2?_v=5.15.1" as="font" type="font/woff2" crossorigin="anonymous" />
+
+	<link rel="stylesheet" href="/css.php?css=public%3Anormalize.css%2Cpublic%3Afa.css%2Cpublic%3Acore.less%2Cpublic%3Aapp.less%2Cpublic%3Alite_yt_embed.css&amp;s=9&amp;l=1&amp;d=1673930653&amp;k=c1038e03e867363b88484049ad500d2361ddcc26" />
+
+	<link rel="stylesheet" href="/css.php?css=public%3Anotices.less%2Cpublic%3Asearch_results.less%2Cpublic%3Aextra.less&amp;s=9&amp;l=1&amp;d=1673930653&amp;k=556b205cb83c842f265a7c6a6fa8528bbf7a5694" />
+
+	
+		<script src="/js/xf/preamble.min.js?_v=761a4b94"></script>
+	
+
+
+	
+	
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-4FBVJFXZ0P"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+		gtag('config', 'G-4FBVJFXZ0P', {
+			// 
+			
+				'cookie_domain': 'mrantifun.net',
+			
+			
+		});
+	</script>
+
+	<script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0112/8510.js" async="async"></script>
+</head>
+<body data-template="search_results">
+
+<div class="p-pageWrapper" id="top">
+
+
+
+
+
+<header class="p-header" id="header">
+	<div class="p-header-inner">
+		<div class="p-header-content">
+
+			<div class="p-header-logo p-header-logo--image">
+				<a href="/">
+					<img src="/styles/gamezone/xenforo/logo.png" srcset="" alt="MrAntiFun, PC Video Game Trainers, Cheats and mods"
+						width="244" height="44" />
+				</a>
+			</div>
+
+			
+		</div>
+	</div>
+</header>
+
+
+
+
+
+	<div class="p-navSticky p-navSticky--primary" data-xf-init="sticky-header">
+		
+	<nav class="p-nav">
+		<div class="p-nav-inner">
+			<button type="button" class="button--plain p-nav-menuTrigger button" data-xf-click="off-canvas" data-menu=".js-headerOffCanvasMenu" tabindex="0" aria-label="Menu"><span class="button-text">
+				<i aria-hidden="true"></i>
+			</span></button>
+
+			<div class="p-nav-smallLogo">
+				<a href="/">
+					<img src="/styles/gamezone/xenforo/logo.png" srcset="" alt="MrAntiFun, PC Video Game Trainers, Cheats and mods"
+						width="244" height="44" />
+				</a>
+			</div>
+
+			<div class="p-nav-scroller hScroller" data-xf-init="h-scroller" data-auto-scroll=".p-navEl.is-selected">
+				<div class="hScroller-scroll">
+					<ul class="p-nav-list js-offCanvasNavSource">
+					
+						<li>
+							
+	<div class="p-navEl " data-has-children="true">
+		
+
+			
+	
+	<a href="/"
+		class="p-navEl-link p-navEl-link--splitMenu "
+		
+		
+		data-nav-id="forums">Forums</a>
+
+
+			<a data-xf-key="1"
+				data-xf-click="menu"
+				data-menu-pos-ref="< .p-navEl"
+				class="p-navEl-splitTrigger"
+				role="button"
+				tabindex="0"
+				aria-label="Toggle expanded"
+				aria-expanded="false"
+				aria-haspopup="true"></a>
+
+		
+		
+			<div class="menu menu--structural" data-menu="menu" aria-hidden="true">
+				<div class="menu-content">
+					
+						
+	
+	
+	<a href="/whats-new/posts/"
+		class="menu-linkRow u-indentDepth0 js-offCanvasCopy "
+		
+		
+		data-nav-id="newPosts">New posts</a>
+
+	
+
+					
+						
+	
+	
+	<a href="/search/?type=post"
+		class="menu-linkRow u-indentDepth0 js-offCanvasCopy "
+		
+		
+		data-nav-id="searchForums">Search forums</a>
+
+	
+
+					
+				</div>
+			</div>
+		
+	</div>
+
+						</li>
+					
+						<li>
+							
+	<div class="p-navEl " >
+		
+
+			
+	
+	<a href="https://mrantifun.net/forums/game-trainers.2/"
+		class="p-navEl-link "
+		
+		data-xf-key="2"
+		data-nav-id="300">Latest Trainers</a>
+
+
+			
+
+		
+		
+	</div>
+
+						</li>
+					
+						<li>
+							
+	<div class="p-navEl " >
+		
+
+			
+	
+	<a href="https://mrantifun.net/index.php?threads/list-of-all-trainers.503/"
+		class="p-navEl-link "
+		
+		data-xf-key="3"
+		data-nav-id="Current_Trainers">Trainers List</a>
+
+
+			
+
+		
+		
+	</div>
+
+						</li>
+					
+						<li>
+							
+	<div class="p-navEl " data-has-children="true">
+		
+
+			
+	
+	<a href="/whats-new/"
+		class="p-navEl-link p-navEl-link--splitMenu "
+		
+		
+		data-nav-id="whatsNew">What's new</a>
+
+
+			<a data-xf-key="4"
+				data-xf-click="menu"
+				data-menu-pos-ref="< .p-navEl"
+				class="p-navEl-splitTrigger"
+				role="button"
+				tabindex="0"
+				aria-label="Toggle expanded"
+				aria-expanded="false"
+				aria-haspopup="true"></a>
+
+		
+		
+			<div class="menu menu--structural" data-menu="menu" aria-hidden="true">
+				<div class="menu-content">
+					
+						
+	
+	
+	<a href="/whats-new/posts/"
+		class="menu-linkRow u-indentDepth0 js-offCanvasCopy "
+		 rel="nofollow"
+		
+		data-nav-id="whatsNewPosts">New posts</a>
+
+	
+
+					
+						
+	
+	
+	<a href="/whats-new/latest-activity"
+		class="menu-linkRow u-indentDepth0 js-offCanvasCopy "
+		 rel="nofollow"
+		
+		data-nav-id="latestActivity">Latest activity</a>
+
+	
+
+					
+				</div>
+			</div>
+		
+	</div>
+
+						</li>
+					
+						<li>
+							
+	<div class="p-navEl " >
+		
+
+			
+	
+	<a href="https://mrantifun.net/index.php?threads/forums-trainers-faq.305/"
+		class="p-navEl-link "
+		
+		data-xf-key="5"
+		data-nav-id="faq">FAQ</a>
+
+
+			
+
+		
+		
+	</div>
+
+						</li>
+					
+					</ul>
+				</div>
+			</div>
+
+			<div class="p-nav-opposite">
+				<div class="p-navgroup p-account p-navgroup--guest">
+					
+						<a href="/login/" class="p-navgroup-link p-navgroup-link--textual p-navgroup-link--logIn"
+							data-xf-click="overlay" data-follow-redirects="on">
+							<span class="p-navgroup-linkText">Log in</span>
+						</a>
+						
+							<a href="/register/" class="p-navgroup-link p-navgroup-link--textual p-navgroup-link--register"
+								data-xf-click="overlay" data-follow-redirects="on">
+								<span class="p-navgroup-linkText">Register</span>
+							</a>
+						
+					
+				</div>
+
+				<div class="p-navgroup p-discovery">
+					<a href="/whats-new/"
+						class="p-navgroup-link p-navgroup-link--iconic p-navgroup-link--whatsnew"
+						aria-label="What&#039;s new"
+						title="What&#039;s new">
+						<i aria-hidden="true"></i>
+						<span class="p-navgroup-linkText">What's new</span>
+					</a>
+
+					
+						<a href="/search/"
+							class="p-navgroup-link p-navgroup-link--iconic p-navgroup-link--search"
+							data-xf-click="menu"
+							data-xf-key="/"
+							aria-label="Search"
+							aria-expanded="false"
+							aria-haspopup="true"
+							title="Search">
+							<i aria-hidden="true"></i>
+							<span class="p-navgroup-linkText">Search</span>
+						</a>
+						<div class="menu menu--structural menu--wide" data-menu="menu" aria-hidden="true">
+							<form action="/search/search" method="post"
+								class="menu-content"
+								data-xf-init="quick-search">
+
+								<h3 class="menu-header">Search</h3>
+								
+								<div class="menu-row">
+									
+										<input type="text" class="input" name="keywords" placeholder="Search…" aria-label="Search" data-menu-autofocus="true" />
+									
+								</div>
+
+								
+								<div class="menu-row">
+									<label class="iconic"><input type="checkbox"  name="c[title_only]" value="1" /><i aria-hidden="true"></i><span class="iconic-label">Search titles only
+
+												
+													<span tabindex="0" role="button"
+														data-xf-init="tooltip" data-trigger="hover focus click" title="Tags will also be searched">
+
+														<i class="fa--xf far fa-question-circle u-muted u-smaller" aria-hidden="true"></i>
+													</span></span></label>
+
+								</div>
+								
+								<div class="menu-row">
+									<div class="inputGroup">
+										<span class="inputGroup-text" id="ctrl_search_menu_by_member">By:</span>
+										<input type="text" class="input" name="c[users]" data-xf-init="auto-complete" placeholder="Member" aria-labelledby="ctrl_search_menu_by_member" />
+									</div>
+								</div>
+								<div class="menu-footer">
+									<span class="menu-footer-controls">
+										<button type="submit" class="button--primary button button--icon button--icon--search"><span class="button-text">Search</span></button>
+										<a href="/search/" class="button"><span class="button-text">Advanced search…</span></a>
+									</span>
+								</div>
+
+								<input type="hidden" name="_xfToken" value="1753044081,66474e5df4315843f5da3454ac773078" />
+							</form>
+						</div>
+					
+				</div>
+			</div>
+		</div>
+	</nav>
+
+	</div>
+	
+	
+		<div class="p-sectionLinks">
+			<div class="p-sectionLinks-inner hScroller" data-xf-init="h-scroller">
+				<div class="hScroller-scroll">
+					<ul class="p-sectionLinks-list">
+					
+						<li>
+							
+	<div class="p-navEl " >
+		
+
+			
+	
+	<a href="/whats-new/latest-activity"
+		class="p-navEl-link "
+		
+		data-xf-key="alt+1"
+		data-nav-id="defaultLatestActivity">Latest activity</a>
+
+
+			
+
+		
+		
+	</div>
+
+						</li>
+					
+						<li>
+							
+	<div class="p-navEl " >
+		
+
+			
+	
+	<a href="/register/"
+		class="p-navEl-link "
+		
+		data-xf-key="alt+2"
+		data-nav-id="defaultRegister">Register</a>
+
+
+			
+
+		
+		
+	</div>
+
+						</li>
+					
+					</ul>
+				</div>
+			</div>
+		</div>
+	
+
+
+
+<div class="offCanvasMenu offCanvasMenu--nav js-headerOffCanvasMenu" data-menu="menu" aria-hidden="true" data-ocm-builder="navigation">
+	<div class="offCanvasMenu-backdrop" data-menu-close="true"></div>
+	<div class="offCanvasMenu-content">
+		<div class="offCanvasMenu-header">
+			Menu
+			<a class="offCanvasMenu-closer" data-menu-close="true" role="button" tabindex="0" aria-label="Close"></a>
+		</div>
+		
+			<div class="p-offCanvasRegisterLink">
+				<div class="offCanvasMenu-linkHolder">
+					<a href="/login/" class="offCanvasMenu-link" data-xf-click="overlay" data-menu-close="true">
+						Log in
+					</a>
+				</div>
+				<hr class="offCanvasMenu-separator" />
+				
+					<div class="offCanvasMenu-linkHolder">
+						<a href="/register/" class="offCanvasMenu-link" data-xf-click="overlay" data-menu-close="true">
+							Register
+						</a>
+					</div>
+					<hr class="offCanvasMenu-separator" />
+				
+			</div>
+		
+		<div class="js-offCanvasNavTarget"></div>
+		<div class="offCanvasMenu-installBanner js-installPromptContainer" style="display: none;" data-xf-init="install-prompt">
+			<div class="offCanvasMenu-installBanner-header">Install the app</div>
+			<button type="button" class="js-installPromptButton button"><span class="button-text">Install</span></button>
+		</div>
+	</div>
+</div>
+
+<div class="p-body">
+	<div class="p-body-inner">
+		<!--XF:EXTRA_OUTPUT-->
+
+		
+
+		
+
+		
+		
+	
+		<ul class="p-breadcrumbs "
+			itemscope itemtype="https://schema.org/BreadcrumbList">
+		
+			
+
+			
+			
+
+			
+			
+				
+				
+	<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+		<a href="https://mrantifun.net/search/" itemprop="item">
+			<span itemprop="name">Search</span>
+		</a>
+		<meta itemprop="position" content="1" />
+	</li>
+
+			
+
+		
+		</ul>
+	
+
+		
+
+		
+	<noscript><div class="blockMessage blockMessage--important blockMessage--iconic u-noJsOnly">JavaScript is disabled. For a better experience, please enable JavaScript in your browser before proceeding.</div></noscript>
+
+		
+	<div class="blockMessage blockMessage--important blockMessage--iconic js-browserWarning" style="display: none">You are using an out of date browser. It  may not display this or other websites correctly.<br />You should upgrade or use an <a href="https://www.google.com/chrome/" target="_blank" rel="noopener">alternative browser</a>.</div>
+
+
+		
+			
+			<div class="p-body-header">
+			
+			
+				<div class="test">
+				
+					<div class="p-title ">
+					
+						
+							<h1 class="p-title-value">Search results for query: <a href="/search/16500161/?searchform=1&amp;q=Hitman&amp;o=date"><em>Hitman</em></a></h1>
+						
+						
+					
+					</div>
+				
+
+				
+			</div>
+			
+			</div>
+		
+
+		<div class="p-body-main  ">
+			
+			<div class="p-body-contentCol"></div>
+			
+
+			
+
+			<div class="p-body-content">
+				
+				<div class="p-body-pageContent">
+	
+	
+
+
+
+
+
+
+
+
+
+
+<div class="block" data-xf-init="" data-type="" data-href="/inline-mod/">
+	
+	
+
+	<div class="block-container">
+		<ol class="block-body">
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="Bomberpilot">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/bomberpilot.779411/" class="avatar avatar--s" data-user-id="779411" data-xf-init="member-tooltip">
+			<img src="/data/avatars/s/779/779411.jpg?1478856876" srcset="/data/avatars/m/779/779411.jpg?1478856876 2x" alt="Bomberpilot" class="avatar-u779411-s" width="48" height="48" loading="lazy" /> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-absolution-trainer.244/post-292290"><em class="textHighlight">Hitman</em> Absolution Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">Dear MrAntiFun,
+
+once again thanks for all your work in the last years!!! I / We need your help with the latest WeMod changes. Your <em class="textHighlight">Hitman</em> - Absolution trainer was perfect; please, please, please re-do / re-update the Abosolution trainer with an Invisible option.
+
+Nothing against your colleague...</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/bomberpilot.779411/" class="username " dir="auto" itemprop="name" data-user-id="779411" data-xf-init="member-tooltip">Bomberpilot</a></li>
+					<li>Post #158</li>
+					<li><time  class="u-dt" dir="auto" datetime="2024-08-20T20:33:13+0300" data-time="1724175193" data-date-string="Aug 20, 2024" data-time-string="8:33 PM" title="Aug 20, 2024 at 8:33 PM">Aug 20, 2024</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="Bomberpilot">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/bomberpilot.779411/" class="avatar avatar--s" data-user-id="779411" data-xf-init="member-tooltip">
+			<img src="/data/avatars/s/779/779411.jpg?1478856876" srcset="/data/avatars/m/779/779411.jpg?1478856876 2x" alt="Bomberpilot" class="avatar-u779411-s" width="48" height="48" loading="lazy" /> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-absolution-completely-remove-detection-including-by-civilians.23876/post-292272"><em class="textHighlight">Hitman</em> Absolution - completely remove detection (including by civilians)</a>
+			</h3>
+
+			<div class="contentRow-snippet">Dear MrAntiFun,
+
+once again thanks for all your work in the last years!!! I / We need your help with the latest WeMod changes. Your <em class="textHighlight">Hitman</em> - Absolution trainer was perfect; please, please, please re-do / re-update the Abosolution trainer with an Invisible option.
+
+Nothing against your colleague...</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/bomberpilot.779411/" class="username " dir="auto" itemprop="name" data-user-id="779411" data-xf-init="member-tooltip">Bomberpilot</a></li>
+					<li>Post #2</li>
+					<li><time  class="u-dt" dir="auto" datetime="2024-08-18T16:30:40+0300" data-time="1723987840" data-date-string="Aug 18, 2024" data-time-string="4:30 PM" title="Aug 18, 2024 at 4:30 PM">Aug 18, 2024</time></li>
+					<li>Forum: <a href="/forums/game-trainer-requests.4/">Game Trainer Requests</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="agwoodliffe">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/agwoodliffe.2418436/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="2418436" data-xf-init="member-tooltip" style="background-color: #5233cc; color: #cbc2f0">
+			<span class="avatar-u2418436-s">A</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-absolution-completely-remove-detection-including-by-civilians.23876/"><em class="textHighlight">Hitman</em> Absolution - completely remove detection (including by civilians)</a>
+			</h3>
+
+			<div class="contentRow-snippet">Title: <em class="textHighlight">Hitman</em> Absolution
+
+Trainer Name: WeMod
+Platform: Steam
+Version: Latest (V1.0.447.0)
+Features Not Working: Civilians still react if you shoot or attack someone. Also, you can technically be spotted by enemies if you attack another. I want a feature that removes NPC detection/reaction ENTIRELY.</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/agwoodliffe.2418436/" class="username " dir="auto" itemprop="name" data-user-id="2418436" data-xf-init="member-tooltip">agwoodliffe</a></li>
+					<li>Thread</li>
+					<li><time  class="u-dt" dir="auto" datetime="2023-04-29T05:09:45+0300" data-time="1682734185" data-date-string="Apr 29, 2023" data-time-string="5:09 AM" title="Apr 29, 2023 at 5:09 AM">Apr 29, 2023</time></li>
+					
+					<li>Replies: 1</li>
+					<li>Forum: <a href="/forums/game-trainer-requests.4/">Game Trainer Requests</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="FluffyMuffins19">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/fluffymuffins19.2170952/" class="avatar avatar--s" data-user-id="2170952" data-xf-init="member-tooltip">
+			<img src="/data/avatars/s/2170/2170952.jpg?1547260478" srcset="/data/avatars/m/2170/2170952.jpg?1547260478 2x" alt="FluffyMuffins19" class="avatar-u2170952-s" width="48" height="48" loading="lazy" /> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-3-trainer.21904/post-279552"><em class="textHighlight">Hitman</em> 3 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">When I try and use it for <em class="textHighlight">Hitman</em> 3 on Epic Games it says loading when I boot up the game but then it says &#039;play&#039; again. Any help?</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/fluffymuffins19.2170952/" class="username " dir="auto" itemprop="name" data-user-id="2170952" data-xf-init="member-tooltip">FluffyMuffins19</a></li>
+					<li>Post #5</li>
+					<li><time  class="u-dt" dir="auto" datetime="2022-07-07T03:22:02+0300" data-time="1657153322" data-date-string="Jul 7, 2022" data-time-string="3:22 AM" title="Jul 7, 2022 at 3:22 AM">Jul 7, 2022</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="MrAntiFun">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/mrantifun.1/" class="avatar avatar--s" data-user-id="1" data-xf-init="member-tooltip">
+			<img src="/data/avatars/s/0/1.jpg?1493654589" srcset="/data/avatars/m/0/1.jpg?1493654589 2x" alt="MrAntiFun" class="avatar-u1-s" width="48" height="48" loading="lazy" /> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-3-trainer.21904/"><em class="textHighlight">Hitman</em> 3 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">Current Trainers:
+<em class="textHighlight">Hitman</em> 3 (Steam) 10-31-23 Trainer +12
+<em class="textHighlight">Hitman</em> 3 (Xbox) 11-2-23 Trainer +12
+<em class="textHighlight">Hitman</em> 3 (Steam) 2-20-24 Trainer +12
+<em class="textHighlight">Hitman</em> 3 (Epic Games) 2-20-24 Trainer +12
+<em class="textHighlight">Hitman</em> 3 (Xbox) 2-28-24 Trainer +12
+<em class="textHighlight">Hitman</em> 3 (Steam) 6-6-24 Trainer +12
+<em class="textHighlight">Hitman</em> 3 (Epic Games) 6-7-24 Trainer +12
+<em class="textHighlight">Hitman</em> 3...</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/mrantifun.1/" class="username " dir="auto" itemprop="name" data-user-id="1" data-xf-init="member-tooltip"><span class="username--staff username--moderator username--admin">MrAntiFun</span></a></li>
+					<li>Thread</li>
+					<li><time  class="u-dt" dir="auto" datetime="2021-01-20T18:48:53+0200" data-time="1611161333" data-date-string="Jan 20, 2021" data-time-string="6:48 PM" title="Jan 20, 2021 at 6:48 PM">Jan 20, 2021</time></li>
+					
+					<li>Replies: 12</li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="darkzone">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/darkzone.38724/" class="avatar avatar--s" data-user-id="38724" data-xf-init="member-tooltip">
+			<img src="/data/avatars/s/38/38724.jpg?1413293183" srcset="/data/avatars/m/38/38724.jpg?1413293183 2x" alt="darkzone" class="avatar-u38724-s" width="48" height="48" loading="lazy" /> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/req-hitman-3.21903/">[REQ] <em class="textHighlight">Hitman</em> 3</a>
+			</h3>
+
+			<div class="contentRow-snippet">Game Name: <em class="textHighlight">Hitman</em> 3
+Game Version: 1
+Options Required: Cheat Table with:
+Infinite Health
+Stealth mode
+Infinite Ammo
+invisible mode
+
+https://www.epicgames.com/store/en-US/p ... man-3/home</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/darkzone.38724/" class="username " dir="auto" itemprop="name" data-user-id="38724" data-xf-init="member-tooltip">darkzone</a></li>
+					<li>Thread</li>
+					<li><time  class="u-dt" dir="auto" datetime="2021-01-20T17:11:25+0200" data-time="1611155485" data-date-string="Jan 20, 2021" data-time-string="5:11 PM" title="Jan 20, 2021 at 5:11 PM">Jan 20, 2021</time></li>
+					
+					<li>Replies: 0</li>
+					<li>Forum: <a href="/forums/game-trainer-requests.4/">Game Trainer Requests</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="MonsterHunter95">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/monsterhunter95.2386541/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="2386541" data-xf-init="member-tooltip" style="background-color: #ebadad; color: #b82e2e">
+			<span class="avatar-u2386541-s">M</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2016-trainer.7406/post-268868"><em class="textHighlight">Hitman</em> 2016 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">how can i use <em class="textHighlight">HITMAN</em> TRAINER in   Epic games? =/</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/monsterhunter95.2386541/" class="username " dir="auto" itemprop="name" data-user-id="2386541" data-xf-init="member-tooltip">MonsterHunter95</a></li>
+					<li>Post #348</li>
+					<li><time  class="u-dt" dir="auto" datetime="2020-08-30T12:44:34+0300" data-time="1598780674" data-date-string="Aug 30, 2020" data-time-string="12:44 PM" title="Aug 30, 2020 at 12:44 PM">Aug 30, 2020</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="MonsterHunter95">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/monsterhunter95.2386541/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="2386541" data-xf-init="member-tooltip" style="background-color: #ebadad; color: #b82e2e">
+			<span class="avatar-u2386541-s">M</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2016-trainer.7406/post-268841"><em class="textHighlight">Hitman</em> 2016 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">I Have Question any Trainer for &#039;&#039;EPIC  GAMES&#039;&#039;  ? because i have  <em class="textHighlight">hitman</em> on epic games and in steam i have <em class="textHighlight">HITMAN</em> 2 ??</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/monsterhunter95.2386541/" class="username " dir="auto" itemprop="name" data-user-id="2386541" data-xf-init="member-tooltip">MonsterHunter95</a></li>
+					<li>Post #347</li>
+					<li><time  class="u-dt" dir="auto" datetime="2020-08-29T16:02:14+0300" data-time="1598706134" data-date-string="Aug 29, 2020" data-time-string="4:02 PM" title="Aug 29, 2020 at 4:02 PM">Aug 29, 2020</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="iamanegg12">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/iamanegg12.508814/" class="avatar avatar--s" data-user-id="508814" data-xf-init="member-tooltip">
+			<img src="/data/avatars/s/508/508814.jpg?1477055707" srcset="/data/avatars/m/508/508814.jpg?1477055707 2x" alt="iamanegg12" class="avatar-u508814-s" width="48" height="48" loading="lazy" /> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2016-trainer.7406/post-261112"><em class="textHighlight">Hitman</em> 2016 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">Hey all just a heads-up. You can play <em class="textHighlight">HITMAN</em> 2016 by downloading and installing <em class="textHighlight">HITMAN</em> 2 on steam as long as you already own the first game. The trainers for <em class="textHighlight">HITMAN</em> 2 are working right now!</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/iamanegg12.508814/" class="username " dir="auto" itemprop="name" data-user-id="508814" data-xf-init="member-tooltip">iamanegg12</a></li>
+					<li>Post #345</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-11-29T11:27:58+0200" data-time="1575019678" data-date-string="Nov 29, 2019" data-time-string="11:27 AM" title="Nov 29, 2019 at 11:27 AM">Nov 29, 2019</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="hurka79">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/hurka79.193899/" class="avatar avatar--s" data-user-id="193899" data-xf-init="member-tooltip">
+			<img src="/data/avatars/s/193/193899.jpg?1492840938" srcset="/data/avatars/m/193/193899.jpg?1492840938 2x" alt="hurka79" class="avatar-u193899-s" width="48" height="48" loading="lazy" /> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2-trainer.17991/post-257289"><em class="textHighlight">Hitman</em> 2 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">Wemod just fine with 2.40 dumb.</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/hurka79.193899/" class="username " dir="auto" itemprop="name" data-user-id="193899" data-xf-init="member-tooltip">hurka79</a></li>
+					<li>Post #112</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-09-25T21:39:55+0300" data-time="1569436795" data-date-string="Sep 25, 2019" data-time-string="9:39 PM" title="Sep 25, 2019 at 9:39 PM">Sep 25, 2019</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="Sr Momos">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/sr-momos.2176108/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="2176108" data-xf-init="member-tooltip" style="background-color: #7a3d1f; color: #db9470">
+			<span class="avatar-u2176108-s">S</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/how-i-can-deactivate-hitman-absolutions-anti-cheat.20253/">how i can deactivate <em class="textHighlight">hitman</em> absolution&#039;s anti cheat?</a>
+			</h3>
+
+			<div class="contentRow-snippet">lol</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/sr-momos.2176108/" class="username " dir="auto" itemprop="name" data-user-id="2176108" data-xf-init="member-tooltip">Sr Momos</a></li>
+					<li>Thread</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-09-13T17:38:29+0300" data-time="1568385509" data-date-string="Sep 13, 2019" data-time-string="5:38 PM" title="Sep 13, 2019 at 5:38 PM">Sep 13, 2019</time></li>
+					
+					<li>Replies: 0</li>
+					<li>Forum: <a href="/forums/general-discussions.8/">General Discussions</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="realjustonce">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/realjustonce.2384550/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="2384550" data-xf-init="member-tooltip" style="background-color: #8f33cc; color: #ddc2f0">
+			<span class="avatar-u2384550-s">R</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2-trainer.17991/post-254773"><em class="textHighlight">Hitman</em> 2 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet"><em class="textHighlight">Hitman</em> 2 (Steam) 8-2-19 Trainer +9 is missing
+
+and WeMod Trainer on 2.40 does not work. Most of us are not using retail Version. (Most recent: 2.40)
+Please Update! :-(</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/realjustonce.2384550/" class="username " dir="auto" itemprop="name" data-user-id="2384550" data-xf-init="member-tooltip">realjustonce</a></li>
+					<li>Post #111</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-08-29T17:34:31+0300" data-time="1567089271" data-date-string="Aug 29, 2019" data-time-string="5:34 PM" title="Aug 29, 2019 at 5:34 PM">Aug 29, 2019</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="xenaxeh">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/xenaxeh.2109236/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="2109236" data-xf-init="member-tooltip" style="background-color: #ebccad; color: #b8732e">
+			<span class="avatar-u2109236-s">X</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2-trainer.17991/post-252455"><em class="textHighlight">Hitman</em> 2 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">Is it possible to get a &quot;one shot kill&quot; option, like we had back in <em class="textHighlight">Hitman</em> 2016?</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/xenaxeh.2109236/" class="username " dir="auto" itemprop="name" data-user-id="2109236" data-xf-init="member-tooltip">xenaxeh</a></li>
+					<li>Post #109</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-08-09T11:30:28+0300" data-time="1565339428" data-date-string="Aug 9, 2019" data-time-string="11:30 AM" title="Aug 9, 2019 at 11:30 AM">Aug 9, 2019</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="skywolf23">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/skywolf23.1450626/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="1450626" data-xf-init="member-tooltip" style="background-color: #3333cc; color: #c2c2f0">
+			<span class="avatar-u1450626-s">S</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2-trainer.17991/post-250253"><em class="textHighlight">Hitman</em> 2 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">Well if you are experiencing crashing in <em class="textHighlight">hitman</em> 2 try going into nvidia and disable the highlights (ansel) feature. 
+
+May have been luck but after reading and trying that i played other night for about an hour with the trainer active and no crashes or anything. 
+
+Nice nvidia can leave ansel...</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/skywolf23.1450626/" class="username " dir="auto" itemprop="name" data-user-id="1450626" data-xf-init="member-tooltip">skywolf23</a></li>
+					<li>Post #104</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-07-16T18:18:37+0300" data-time="1563290317" data-date-string="Jul 16, 2019" data-time-string="6:18 PM" title="Jul 16, 2019 at 6:18 PM">Jul 16, 2019</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="General Ko">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/general-ko.1669637/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="1669637" data-xf-init="member-tooltip" style="background-color: #e08585; color: #8f2424">
+			<span class="avatar-u1669637-s">G</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2-trainer.17991/post-249333"><em class="textHighlight">Hitman</em> 2 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">Do you have to go Offline on Steam and Disconnect your internet? Only Steam offline enough?</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/general-ko.1669637/" class="username " dir="auto" itemprop="name" data-user-id="1669637" data-xf-init="member-tooltip">General Ko</a></li>
+					<li>Post #102</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-07-08T02:24:50+0300" data-time="1562541890" data-date-string="Jul 8, 2019" data-time-string="2:24 AM" title="Jul 8, 2019 at 2:24 AM">Jul 8, 2019</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="LunarX">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/lunarx.260560/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="260560" data-xf-init="member-tooltip" style="background-color: #143352; color: #478cd1">
+			<span class="avatar-u260560-s">L</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2-trainer.17991/post-248472"><em class="textHighlight">Hitman</em> 2 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">Works fine with the current build/version of the game.</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/lunarx.260560/" class="username " dir="auto" itemprop="name" data-user-id="260560" data-xf-init="member-tooltip">LunarX</a></li>
+					<li>Post #97</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-06-30T21:53:58+0300" data-time="1561920838" data-date-string="Jun 30, 2019" data-time-string="9:53 PM" title="Jun 30, 2019 at 9:53 PM">Jun 30, 2019</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="spop1992">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/spop1992.2353610/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="2353610" data-xf-init="member-tooltip" style="background-color: #663333; color: #c38888">
+			<span class="avatar-u2353610-s">S</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2-trainer.17991/post-248433"><em class="textHighlight">Hitman</em> 2 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">update Trainer <em class="textHighlight">hitman</em> 2  version 2.40.0 (25.06.2019) -please....</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/spop1992.2353610/" class="username " dir="auto" itemprop="name" data-user-id="2353610" data-xf-init="member-tooltip">spop1992</a></li>
+					<li>Post #96</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-06-30T16:37:29+0300" data-time="1561901849" data-date-string="Jun 30, 2019" data-time-string="4:37 PM" title="Jun 30, 2019 at 4:37 PM">Jun 30, 2019</time></li>
+					<li>Forum: <a href="/forums/game-trainers.2/">Game Trainers</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="mxstake">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/mxstake.161283/" class="avatar avatar--s" data-user-id="161283" data-xf-init="member-tooltip">
+			<img src="/data/avatars/s/161/161283.jpg?1537638468" srcset="/data/avatars/m/161/161283.jpg?1537638468 2x" alt="mxstake" class="avatar-u161283-s" width="48" height="48" loading="lazy" /> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/update-request-hitman-2-trainer-2018-to-ver_2-30-0.19730/">{Update Request} <em class="textHighlight">Hitman</em> 2 Trainer (2018) To Ver_2.30.0</a>
+			</h3>
+
+			<div class="contentRow-snippet">A lot of people already asking if there will be any updates on the trainer, every time you start the game and lunch the trainer it crashes, will be extremely grateful if this matter can be fixed.</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/mxstake.161283/" class="username " dir="auto" itemprop="name" data-user-id="161283" data-xf-init="member-tooltip">mxstake</a></li>
+					<li>Thread</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-06-23T05:07:24+0300" data-time="1561255644" data-date-string="Jun 23, 2019" data-time-string="5:07 AM" title="Jun 23, 2019 at 5:07 AM">Jun 23, 2019</time></li>
+					
+					<li>Replies: 1</li>
+					<li>Forum: <a href="/forums/game-trainer-requests.4/">Game Trainer Requests</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="MrSkaizo">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/mrskaizo.9407/" class="avatar avatar--s" data-user-id="9407" data-xf-init="member-tooltip">
+			<img src="/data/avatars/s/9/9407.jpg?1484078051" srcset="/data/avatars/m/9/9407.jpg?1484078051 2x" alt="MrSkaizo" class="avatar-u9407-s" width="48" height="48" loading="lazy" /> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2-trainer.19292/post-240663"><em class="textHighlight">Hitman</em> 2 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet"># Trainer Update Request Completed
+# Link: https://mrantifun.net/index.php?threads/<em class="textHighlight">hitman</em>-2-trainer.17991/
+# Platform: Steam
+# Cheats Added: -
+# Trainer Engine Version: V1.03 (64-bit)
+# Game Version: Build 3769198  // V02.05.2019 
+# VirusTotal Report: URL
+
+As always, don&#039;t forget to read notice...</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/mrskaizo.9407/" class="username " dir="auto" itemprop="name" data-user-id="9407" data-xf-init="member-tooltip"><span class="username--staff username--moderator">MrSkaizo</span></a></li>
+					<li>Post #2</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-05-04T12:39:14+0300" data-time="1556962754" data-date-string="May 4, 2019" data-time-string="12:39 PM" title="May 4, 2019 at 12:39 PM">May 4, 2019</time></li>
+					<li>Forum: <a href="/forums/game-trainer-requests.4/">Game Trainer Requests</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+				<li class="block-row block-row--separated  js-inlineModContainer" data-author="Locksley47">
+	<div class="contentRow ">
+		<span class="contentRow-figure">
+			<a href="/members/locksley47.2288309/" class="avatar avatar--s avatar--default avatar--default--dynamic" data-user-id="2288309" data-xf-init="member-tooltip" style="background-color: #663333; color: #c38888">
+			<span class="avatar-u2288309-s">L</span> 
+		</a>
+		</span>
+		<div class="contentRow-main">
+			<h3 class="contentRow-title">
+				<a href="/threads/hitman-2-trainer.19292/"><em class="textHighlight">Hitman</em> 2 Trainer</a>
+			</h3>
+
+			<div class="contentRow-snippet">The recent update has broken most of the cheats on the trainer.
+
+Trainer link:
+
+https://mrantifun.net/index.php?threads/<em class="textHighlight">hitman</em>-2-trainer.17991/</div>
+
+			<div class="contentRow-minor contentRow-minor--hideLinks">
+				<ul class="listInline listInline--bullet">
+					
+					<li><a href="/members/locksley47.2288309/" class="username " dir="auto" itemprop="name" data-user-id="2288309" data-xf-init="member-tooltip">Locksley47</a></li>
+					<li>Thread</li>
+					<li><time  class="u-dt" dir="auto" datetime="2019-05-01T01:37:25+0300" data-time="1556663845" data-date-string="May 1, 2019" data-time-string="1:37 AM" title="May 1, 2019 at 1:37 AM">May 1, 2019</time></li>
+					
+					<li>Replies: 1</li>
+					<li>Forum: <a href="/forums/game-trainer-requests.4/">Game Trainer Requests</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</li>
+			
+		</ol>
+		
+	</div>
+
+	<div class="block-outer block-outer--after">
+		<div class="block-outer-main"><nav class="pageNavWrapper pageNavWrapper--mixed ">
+
+
+
+<div class="pageNav  pageNav--skipEnd">
+	
+
+	<ul class="pageNav-main">
+		
+
+	
+		<li class="pageNav-page pageNav-page--current "><a href="/search/16500161/?q=Hitman&amp;o=date">1</a></li>
+	
+
+
+		
+
+		
+			
+
+	
+		<li class="pageNav-page pageNav-page--later"><a href="/search/16500161/?page=2&amp;q=Hitman&amp;o=date">2</a></li>
+	
+
+		
+			
+
+	
+		<li class="pageNav-page pageNav-page--later"><a href="/search/16500161/?page=3&amp;q=Hitman&amp;o=date">3</a></li>
+	
+
+		
+
+		
+			
+				<li class="pageNav-page pageNav-page--skip pageNav-page--skipEnd">
+					<a data-xf-init="tooltip" title="Go to page"
+						data-xf-click="menu"
+						role="button" tabindex="0" aria-expanded="false" aria-haspopup="true">…</a>
+					
+
+	<div class="menu menu--pageJump" data-menu="menu" aria-hidden="true">
+		<div class="menu-content">
+			<h4 class="menu-header">Go to page</h4>
+			<div class="menu-row" data-xf-init="page-jump" data-page-url="/search/16500161/?page=%25page%25&amp;q=Hitman&amp;o=date">
+				<div class="inputGroup inputGroup--numbers">
+					<div class="inputGroup inputGroup--numbers inputNumber" data-xf-init="number-box"><input type="number" pattern="\d*" class="input input--number js-numberBoxTextInput input input--numberNarrow js-pageJumpPage" value="4"  min="1" max="6" step="1" required="required" data-menu-autofocus="true" /></div>
+					<span class="inputGroup-text"><button type="button" class="js-pageJumpGo button"><span class="button-text">Go</span></button></span>
+				</div>
+			</div>
+		</div>
+	</div>
+
+				</li>
+			
+		
+
+		
+
+	
+		<li class="pageNav-page "><a href="/search/16500161/?page=6&amp;q=Hitman&amp;o=date">6</a></li>
+	
+
+	</ul>
+
+	
+		<a href="/search/16500161/?page=2&amp;q=Hitman&amp;o=date" class="pageNav-jump pageNav-jump--next">Next</a>
+	
+</div>
+
+<div class="pageNavSimple">
+	
+
+	<a class="pageNavSimple-el pageNavSimple-el--current"
+		data-xf-init="tooltip" title="Go to page"
+		data-xf-click="menu" role="button" tabindex="0" aria-expanded="false" aria-haspopup="true">
+		1 of 6
+	</a>
+	
+
+	<div class="menu menu--pageJump" data-menu="menu" aria-hidden="true">
+		<div class="menu-content">
+			<h4 class="menu-header">Go to page</h4>
+			<div class="menu-row" data-xf-init="page-jump" data-page-url="/search/16500161/?page=%25page%25&amp;q=Hitman&amp;o=date">
+				<div class="inputGroup inputGroup--numbers">
+					<div class="inputGroup inputGroup--numbers inputNumber" data-xf-init="number-box"><input type="number" pattern="\d*" class="input input--number js-numberBoxTextInput input input--numberNarrow js-pageJumpPage" value="1"  min="1" max="6" step="1" required="required" data-menu-autofocus="true" /></div>
+					<span class="inputGroup-text"><button type="button" class="js-pageJumpGo button"><span class="button-text">Go</span></button></span>
+				</div>
+			</div>
+		</div>
+	</div>
+
+
+	
+		<a href="/search/16500161/?page=2&amp;q=Hitman&amp;o=date" class="pageNavSimple-el pageNavSimple-el--next">
+			Next <i aria-hidden="true"></i>
+		</a>
+		<a href="/search/16500161/?page=6&amp;q=Hitman&amp;o=date"
+			class="pageNavSimple-el pageNavSimple-el--last"
+			data-xf-init="tooltip" title="Last">
+			<i aria-hidden="true"></i> <span class="u-srOnly">Last</span>
+		</a>
+	
+</div>
+
+</nav>
+
+
+
+</div>
+		
+	</div>
+</div>
+
+</div>
+				
+			</div>
+
+			
+		</div>
+
+		
+		
+	
+		<ul class="p-breadcrumbs p-breadcrumbs--bottom"
+			itemscope itemtype="https://schema.org/BreadcrumbList">
+		
+			
+
+			
+			
+
+			
+			
+				
+				
+	<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+		<a href="https://mrantifun.net/search/" itemprop="item">
+			<span itemprop="name">Search</span>
+		</a>
+		<meta itemprop="position" content="1" />
+	</li>
+
+			
+
+		
+		</ul>
+	
+
+		
+	</div>
+</div>
+
+<footer class="p-footer" id="footer">
+	<div class="p-footer-inner">
+
+		<div class="p-footer-row">
+			
+			<div class="p-footer-row-opposite">
+				<ul class="p-footer-linkList">
+					
+						
+							<li><a href="/misc/contact" data-xf-click="overlay">Contact us</a></li>
+						
+					
+
+					
+						<li><a href="/help/terms/">Terms and rules</a></li>
+					
+
+					
+						<li><a href="pivacypolicy.php">Privacy policy</a></li>
+					
+
+					
+						<li><a href="/help/">Help</a></li>
+					
+
+					
+
+					<li><a href="/forums/-/index.rss" target="_blank" class="p-footer-rssLink" title="RSS"><span aria-hidden="true"><i class="fa--xf far fa-rss" aria-hidden="true"></i><span class="u-srOnly">RSS</span></span></a></li>
+				</ul>
+			</div>
+		</div>
+
+		
+
+		
+	</div>
+</footer>
+
+</div> <!-- closing p-pageWrapper -->
+
+<div class="u-bottomFixer js-bottomFixTarget">
+	
+	
+		
+	
+		
+		
+		
+
+		<ul class="notices notices--bottom_fixer  js-notices"
+			data-xf-init="notices"
+			data-type="bottom_fixer"
+			data-scroll-interval="6">
+
+			
+				
+	<li class="notice js-notice notice--primary notice--cookie"
+		data-notice-id="-1"
+		data-delay-duration="0"
+		data-display-duration="0"
+		data-auto-dismiss="0"
+		data-visibility="">
+
+		
+		<div class="notice-content">
+			
+			<div class="u-alignCenter">
+	This site uses cookies to help personalise content, tailor your experience and to keep you logged in if you register.<br />
+By continuing to use this site, you are consenting to our use of cookies.
+</div>
+
+<div class="u-inputSpacer u-alignCenter">
+	<a href="/account/dismiss-notice" class="js-noticeDismiss button--notice button button--icon button--icon--confirm"><span class="button-text">Accept</span></a>
+	<a href="/help/cookies" class="button--notice button"><span class="button-text">Learn more…</span></a>
+</div>
+		</div>
+	</li>
+
+			
+		</ul>
+	
+
+	
+</div>
+
+
+	<div class="u-scrollButtons js-scrollButtons" data-trigger-type="up">
+		<a href="#top" class="button--scroll button" data-xf-click="scroll-to"><span class="button-text"><i class="fa--xf far fa-arrow-up" aria-hidden="true"></i><span class="u-srOnly">Top</span></span></a>
+		
+	</div>
+
+	
+
+
+
+	<script src="/js/vendor/jquery/jquery-3.5.1.min.js?_v=761a4b94"></script>
+	<script src="/js/vendor/vendor-compiled.js?_v=761a4b94"></script>
+	<script src="/js/xf/core-compiled.js?_v=761a4b94"></script>
+	<script src="/js/xf/notice.min.js?_v=761a4b94"></script>
+
+	<script>
+		jQuery.extend(true, XF.config, {
+			// 
+			userId: 0,
+			enablePush: false,
+			pushAppServerKey: '',
+			url: {
+				fullBase: 'https://mrantifun.net/',
+				basePath: '/',
+				css: '/css.php?css=__SENTINEL__&s=9&l=1&d=1673930653',
+				keepAlive: '/login/keep-alive'
+			},
+			cookie: {
+				path: '/',
+				domain: 'mrantifun.net',
+				prefix: 'maf_',
+				secure: true
+			},
+			cacheKey: 'bef80e73f2f0e231f520f46dee04af5f',
+			csrf: '1753044081,66474e5df4315843f5da3454ac773078',
+			js: {"\/js\/xf\/notice.min.js?_v=761a4b94":true},
+			css: {"public:notices.less":true,"public:search_results.less":true,"public:extra.less":true},
+			time: {
+				now: 1753044081,
+				today: 1752958800,
+				todayDow: 0,
+				tomorrow: 1753045200,
+				yesterday: 1752872400,
+				week: 1752440400
+			},
+			borderSizeFeature: '3px',
+			fontAwesomeWeight: 'r',
+			enableRtnProtect: true,
+			enableFormSubmitSticky: true,
+			uploadMaxFilesize: 10485760,
+			allowedVideoExtensions: ["m4v","mov","mp4","mp4v","mpeg","mpg","ogv","webm"],
+			allowedAudioExtensions: ["mp3","ogg","wav"],
+			shortcodeToEmoji: true,
+			visitorCounts: {
+				conversations_unread: '0',
+				alerts_unviewed: '0',
+				total_unread: '0',
+				title_count: true,
+				icon_indicator: true
+			},
+			jsState: {},
+			publicMetadataLogoUrl: '',
+			publicPushBadgeUrl: 'https://mrantifun.net/styles/default/xenforo/bell.png'
+		});
+
+		jQuery.extend(XF.phrases, {
+			// 
+			date_x_at_time_y: "{date} at {time}",
+			day_x_at_time_y:  "{day} at {time}",
+			yesterday_at_x:   "Yesterday at {time}",
+			x_minutes_ago:    "{minutes} minutes ago",
+			one_minute_ago:   "1 minute ago",
+			a_moment_ago:     "A moment ago",
+			today_at_x:       "Today at {time}",
+			in_a_moment:      "In a moment",
+			in_a_minute:      "In a minute",
+			in_x_minutes:     "In {minutes} minutes",
+			later_today_at_x: "Later today at {time}",
+			tomorrow_at_x:    "Tomorrow at {time}",
+
+			day0: "Sunday",
+			day1: "Monday",
+			day2: "Tuesday",
+			day3: "Wednesday",
+			day4: "Thursday",
+			day5: "Friday",
+			day6: "Saturday",
+
+			dayShort0: "Sun",
+			dayShort1: "Mon",
+			dayShort2: "Tue",
+			dayShort3: "Wed",
+			dayShort4: "Thu",
+			dayShort5: "Fri",
+			dayShort6: "Sat",
+
+			month0: "January",
+			month1: "February",
+			month2: "March",
+			month3: "April",
+			month4: "May",
+			month5: "June",
+			month6: "July",
+			month7: "August",
+			month8: "September",
+			month9: "October",
+			month10: "November",
+			month11: "December",
+
+			active_user_changed_reload_page: "The active user has changed. Reload the page for the latest version.",
+			server_did_not_respond_in_time_try_again: "The server did not respond in time. Please try again.",
+			oops_we_ran_into_some_problems: "Oops! We ran into some problems.",
+			oops_we_ran_into_some_problems_more_details_console: "Oops! We ran into some problems. Please try again later. More error details may be in the browser console.",
+			file_too_large_to_upload: "The file is too large to be uploaded.",
+			uploaded_file_is_too_large_for_server_to_process: "The uploaded file is too large for the server to process.",
+			files_being_uploaded_are_you_sure: "Files are still being uploaded. Are you sure you want to submit this form?",
+			attach: "Attach files",
+			rich_text_box: "Rich text box",
+			close: "Close",
+			link_copied_to_clipboard: "Link copied to clipboard.",
+			text_copied_to_clipboard: "Text copied to clipboard.",
+			loading: "Loading…",
+
+			processing: "Processing",
+			'processing...': "Processing…",
+
+			showing_x_of_y_items: "Showing {count} of {total} items",
+			showing_all_items: "Showing all items",
+			no_items_to_display: "No items to display",
+
+			number_button_up: "Increase",
+			number_button_down: "Decrease",
+
+			push_enable_notification_title: "Push notifications enabled successfully at MrAntiFun, PC Video Game Trainers, Cheats and mods",
+			push_enable_notification_body: "Thank you for enabling push notifications!"
+		});
+	</script>
+
+	<form style="display:none" hidden="hidden">
+		<input type="text" name="_xfClientLoadTime" value="" id="_xfClientLoadTime" title="_xfClientLoadTime" tabindex="-1" />
+	</form>
+
+	
+
+
+
+
+
+
+</body>
+</html>
+
+
+
+
+
+
+
+
+

--- a/tests/providers/test_mrantifun.py
+++ b/tests/providers/test_mrantifun.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from cheater.providers.mrantifun import MrAntiFunProvider
+
+
+def test_parse_search_results(tmp_path):
+    sample_html = (
+        Path(__file__).with_name("sample_search.html").read_text(encoding="utf-8")
+    )
+    provider = MrAntiFunProvider()
+    results = list(provider.parse_search_results(sample_html))
+    assert results, "No results parsed"
+    first = results[0]
+    assert first.title
+    assert first.url.startswith("https://mrantifun.net/"), first.url


### PR DESCRIPTION
## Summary
- implement `MrAntiFunProvider` for scraping trainers from mrantifun.net
- expose unified `search_all` helper
- add tests exercising HTML parsing logic

## Testing
- `ruff format cheater tests --quiet`
- `ruff check cheater tests --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5367e92c83328fb8b38b359ab76d